### PR TITLE
Ensure support for Gradle 8.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,16 @@ A Gradle plugin for generating JSON schemas from code using the [Creel JSON Sche
 
 See [CreekService.org](https://www.creekservice.org) for info on Creek Service.
 
-> ### NOTE
-> The plugin works with Gradle 6.4 and above.
+-## Supported Gradle versions
+
+| Gradle Version | Tested version | Notes                                       |
+|----------------|----------------|---------------------------------------------|
+| < 6.4          |                | Not compatible due to API changes in Gradle |
+| 6.4.+          | 6.4            | Supported & tested                          |
+| 6.4+           | 6.9.4          | Supported & tested                          |
+| 7.+            | 7.6.1          | Supported & tested                          |
+| 8.+            | 8.0.2          | Supported & tested                          |
+| > 8.0.2        |                | Not currently tested. Should work...        |
 
 ## Usage
 

--- a/src/test/java/org/creekservice/api/json/schema/gradle/plugin/task/GenerateJsonSchemaTest.java
+++ b/src/test/java/org/creekservice/api/json/schema/gradle/plugin/task/GenerateJsonSchemaTest.java
@@ -429,7 +429,8 @@ class GenerateJsonSchemaTest {
     @SuppressWarnings("unused") // Invoked by reflection
     private static ArgumentSets flavoursAndVersions() {
         final Collection<?> flavours = List.of("kotlin", "groovy");
-        final Collection<?> gradleVersions = List.of("6.4", "6.9.2", "7.0", "7.4.2");
+        // Note: update root README.md when updating this test dimension:
+        final Collection<?> gradleVersions = List.of("6.4", "6.9.4", "7.6.1", "8.0.2");
         return ArgumentSets.argumentsForFirstParameter(flavours)
                 .argumentsForNextParameter(gradleVersions);
     }

--- a/src/test/resources/projects/functional/groovy/generates_schema/kotlin/build.gradle
+++ b/src/test/resources/projects/functional/groovy/generates_schema/kotlin/build.gradle
@@ -16,7 +16,7 @@
 
 plugins {
     id 'org.creekservice.schema.json'
-    id 'org.jetbrains.kotlin.jvm' version '1.5.31'
+    id 'org.jetbrains.kotlin.jvm' version '1.6.21'
     id 'java-library'
 }
 

--- a/src/test/resources/projects/functional/kotlin/generates_schema/kotlin/build.gradle.kts
+++ b/src/test/resources/projects/functional/kotlin/generates_schema/kotlin/build.gradle.kts
@@ -16,7 +16,7 @@
 
 plugins {
     id("org.creekservice.schema.json")
-    id("org.jetbrains.kotlin.jvm") version "1.5.31"
+    id("org.jetbrains.kotlin.jvm") version "1.6.21"
     `java-library`
 }
 


### PR DESCRIPTION
Gradle 8 supported without change.

Tests needed updating to use version of Kotlin compatible with both Gradle 6.4 and 8.x

### Reviewer checklist
 - [ ] Read the [contributing guide](https://github.com/creek-service/.github/blob/main/CONTRIBUTING.md)
 - [ ] PR should be motivated, i.e. what does it fix, why, and if relevant, how
 - [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
 - [ ] Ensure any appropriate documentation has been added or amended
