### PR TITLE
Fix module whitelisting

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,17 @@
+#
+# Copyright 2023 Creek Contributors (https://github.com/creek-service)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.gradle.parallel=true

--- a/src/main/java/org/creekservice/api/json/schema/gradle/plugin/JsonSchemaExtension.java
+++ b/src/main/java/org/creekservice/api/json/schema/gradle/plugin/JsonSchemaExtension.java
@@ -42,6 +42,11 @@ public abstract class JsonSchemaExtension implements ExtensionAware {
          *
          * <p>Default: empty, meaning all modules will be scanned.
          *
+         * <p><b>NOTE</b>: Setting a non-empty module whitelist also causes the schema generator to
+         * be executed from the module-path, rather than the default class-path, i.e. the generator
+         * will run under the JPMS. This can run into issues with split packages, i.e. the same
+         * package exposed from multiple jars.
+         *
          * @return the module whitelist property
          */
         public abstract ListProperty<String> getModuleWhiteList();
@@ -134,7 +139,9 @@ public abstract class JsonSchemaExtension implements ExtensionAware {
     /**
      * Optional list of additional arguments to pass to the generator.
      *
-     * <p>See https://github.com/creek-service/creek-json-schema/tree/main/generator for more info.
+     * <p>See the <a
+     * href="https://github.com/creek-service/creek-json-schema/tree/main/generator">docs</a> for
+     * more info.
      *
      * <p>Default: none.
      *

--- a/src/test/java/org/creekservice/api/json/schema/gradle/plugin/task/GenerateJsonSchemaTest.java
+++ b/src/test/java/org/creekservice/api/json/schema/gradle/plugin/task/GenerateJsonSchemaTest.java
@@ -130,6 +130,13 @@ class GenerateJsonSchemaTest {
                 matchesPattern(
                         Pattern.compile(
                                 ".*--class-path=.*build/classes/java/main:.*", Pattern.DOTALL)));
+        assertThat(
+                "Should be running from the class-path",
+                result.getOutput(),
+                matchesPattern(
+                        Pattern.compile(
+                                ".*^--class-path=[^\n\r]*creek-json-schema-generator.*",
+                                Pattern.MULTILINE | Pattern.DOTALL)));
     }
 
     @CartesianTest
@@ -178,6 +185,13 @@ class GenerateJsonSchemaTest {
                 containsString(
                         "--subtype-scanning-allowed-packages=[com.acme.test.sub,"
                                 + " com.acme.models.sub]"));
+        assertThat(
+                "Should be running from the module-path",
+                result.getOutput(),
+                matchesPattern(
+                        Pattern.compile(
+                                ".*^--module-path=[^\n\r]*creek-json-schema-generator.*",
+                                Pattern.MULTILINE | Pattern.DOTALL)));
     }
 
     @CartesianTest


### PR DESCRIPTION
fixes: https://github.com/creek-service/creek-json-schema-gradle-plugin/issues/122

The Gradle plugin was executing the generator with modules on the class-path, meaning they had no module name.

The fix was to have the plugin execute the generator with modules on the module-path.


### Reviewer checklist
 - [ ] Read the [contributing guide](https://github.com/creek-service/.github/blob/main/CONTRIBUTING.md)
 - [ ] PR should be motivated, i.e. what does it fix, why, and if relevant, how
 - [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
 - [ ] Ensure any appropriate documentation has been added or amended
