### PR TITLE
Disable coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Build
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-        run: ./gradlew build coveralls
+        run: ./gradlew build
       - name: Publish
         if: github.event_name == 'push' || github.event.inputs.publish_artifacts == 'true'
         env:


### PR DESCRIPTION
Generation of test coverage data is currently failing with error:

```
Unable to read execution data file /home/runner/work/creek-json-schema-gradle-plugin/creek-json-schema-gradle-plugin/build/jacoco/test.exec
```

But only on build servers.

Though I'm loathed to do it, I'm disabling coverage until I have time to investigate, as this is blocking builds for dependency updates etc.

Task https://github.com/creek-service/creek-json-schema-gradle-plugin/issues/212 tracks fixing the issue.
