### PR TITLE
Use runtime classpath to run generator

### DIFF
--- a/src/main/java/org/creekservice/api/json/schema/gradle/plugin/JsonSchemaPlugin.java
+++ b/src/main/java/org/creekservice/api/json/schema/gradle/plugin/JsonSchemaPlugin.java
@@ -122,7 +122,7 @@ public final class JsonSchemaPlugin implements Plugin<Project> {
                         afterEvaluate(
                                 proj,
                                 GENERATE_SCHEMA_TASK_NAME,
-                                JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME,
+                                JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME,
                                 List.of(
                                         JavaPlugin.COMPILE_JAVA_TASK_NAME,
                                         "compileKotlin",
@@ -144,7 +144,7 @@ public final class JsonSchemaPlugin implements Plugin<Project> {
                         afterEvaluate(
                                 proj,
                                 GENERATE_TEST_SCHEMA_TASK_NAME,
-                                JavaPlugin.TEST_COMPILE_CLASSPATH_CONFIGURATION_NAME,
+                                JavaPlugin.TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME,
                                 List.of(
                                         JavaPlugin.COMPILE_TEST_JAVA_TASK_NAME,
                                         "compileTestKotlin",

--- a/src/main/java/org/creekservice/api/json/schema/gradle/plugin/task/GenerateJsonSchema.java
+++ b/src/main/java/org/creekservice/api/json/schema/gradle/plugin/task/GenerateJsonSchema.java
@@ -255,14 +255,12 @@ public abstract class GenerateJsonSchema extends DefaultTask {
         final List<String> arguments = arguments();
         final List<String> jvmArgs = jvmArgs();
 
-        if (getLogger().isInfoEnabled()) {
-            getLogger().info("Executing JSON schema generator with:");
-            getLogger().info("useModulePath: {}", useModulePath);
-            getLogger().info("arguments: {}", arguments);
-            getLogger().info("jvmArgs: {}", jvmArgs);
-            getLogger().info("classpath:");
-            classPath.forEach(f -> getLogger().info(f.getAbsolutePath()));
-        }
+        getLogger().info("Executing JSON schema generator with:");
+        getLogger().info("useModulePath: {}", useModulePath);
+        getLogger().info("arguments: {}", arguments);
+        getLogger().info("jvmArgs: {}", jvmArgs);
+        getLogger().info("classpath:");
+        classPath.forEach(f -> getLogger().info(f.getAbsolutePath()));
 
         getProject()
                 .javaexec(

--- a/src/main/java/org/creekservice/api/json/schema/gradle/plugin/task/GenerateJsonSchema.java
+++ b/src/main/java/org/creekservice/api/json/schema/gradle/plugin/task/GenerateJsonSchema.java
@@ -251,6 +251,19 @@ public abstract class GenerateJsonSchema extends DefaultTask {
     public void run() {
         checkDependenciesIncludesRunner();
 
+        final boolean useModulePath = useModulePath();
+        final List<String> arguments = arguments();
+        final List<String> jvmArgs = jvmArgs();
+
+        if (getLogger().isInfoEnabled()) {
+            getLogger().info("Executing JSON schema generator with:");
+            getLogger().info("useModulePath: {}", useModulePath);
+            getLogger().info("arguments: {}", arguments);
+            getLogger().info("jvmArgs: {}", jvmArgs);
+            getLogger().info("classpath:");
+            classPath.forEach(f -> getLogger().info(f.getAbsolutePath()));
+        }
+
         getProject()
                 .javaexec(
                         spec -> {
@@ -258,10 +271,10 @@ public abstract class GenerateJsonSchema extends DefaultTask {
                                     .set(
                                             "org.creekservice.api.json.schema.generator.JsonSchemaGenerator");
                             spec.getMainModule().set("creek.json.schema.generator");
-                            spec.getModularity().getInferModulePath().set(useModulePath());
+                            spec.getModularity().getInferModulePath().set(useModulePath);
                             spec.setClasspath(classPath);
-                            spec.setArgs(arguments());
-                            spec.jvmArgs(jvmArgs());
+                            spec.setArgs(arguments);
+                            spec.jvmArgs(jvmArgs);
                         });
     }
 


### PR DESCRIPTION
fixes: https://github.com/creek-service/creek-json-schema-gradle-plugin/issues/260

The old use of compile time classpath wasn't bringing in transient dependencies from modules. Using runtime classpath does.

Also added some logging to help debug future issues.
