### PR TITLE
fix: replace unmaintained coveralls Gradle plugin with coverallsapp/github-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,12 +42,14 @@ jobs:
         with:
           gradle-home-cache-cleanup: true
       - name: Build
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-          CI_NAME: github-actions
-          CI_JOB_ID: ${{ github.run_id }}
-          CI_PULL_REQUEST: ${{ github.event.pull_request.number }}
-        run: ./gradlew build coveralls
+        run: ./gradlew build
+
+      - name: Upload coverage to Coveralls
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          file: build/reports/jacoco/coverage/coverage.xml
+          format: jacoco
       - name: Upload Reports
         if: failure()
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -39,7 +39,6 @@ kotlin {
 dependencies {
     implementation("com.github.spotbugs.snom:spotbugs-gradle-plugin:6.2.2")                // https://plugins.gradle.org/plugin/com.github.spotbugs
     implementation("com.diffplug.spotless:spotless-plugin-gradle:7.2.1")                   // https://plugins.gradle.org/plugin/com.diffplug.spotless
-    implementation("gradle.plugin.org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.12.2")   // https://plugins.gradle.org/plugin/com.github.kt3k.coveralls
     implementation("org.javamodularity:moduleplugin:1.8.15")                                // https://plugins.gradle.org/plugin/org.javamodularity.moduleplugin
     implementation("io.github.gradle-nexus:publish-plugin:2.0.0")                           // https://plugins.gradle.org/plugin/io.github.gradle-nexus.publish-plugin
     implementation("com.gradle.publish:plugin-publish-plugin:1.3.1")                        // https://plugins.gradle.org/plugin/com.gradle.plugin-publish

--- a/buildSrc/src/main/kotlin/creek-coverage-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/creek-coverage-convention.gradle.kts
@@ -25,7 +25,6 @@
 plugins {
     java
     jacoco
-    id("com.github.kt3k.coveralls")
 }
 
 repositories {
@@ -60,17 +59,4 @@ val coverage = tasks.register<JacocoReport>("coverage") {
         xml.required.set(true)
         html.required.set(true)
     }
-}
-
-coveralls {
-    sourceDirs = allprojects.flatMap{it.sourceSets.main.get().allSource.srcDirs}.map{it.toString()}
-    jacocoReportPath = layout.buildDirectory.file("reports/jacoco/coverage/coverage.xml")
-}
-
-tasks.coveralls {
-    group = "creek"
-    description = "Uploads the aggregated coverage report to Coveralls"
-
-    dependsOn(coverage)
-    onlyIf{System.getenv("CI") != null}
 }


### PR DESCRIPTION
The coveralls-gradle-plugin v2.12.2 has not been maintained since 2021 and uses the `getDependencyProject()` API that was removed in Gradle 9, causing builds to fail with Gradle 9.x.

Replace with the `coverallsapp/github-action` GitHub Action which uploads the Jacoco XML report directly to Coveralls without a Gradle plugin.