### PR TITLE
fix: escape backslashes in gradle.properties for Windows path compatibility

### DIFF
--- a/src/test/java/org/creekservice/api/json/schema/gradle/plugin/task/GenerateJsonSchemaTest.java
+++ b/src/test/java/org/creekservice/api/json/schema/gradle/plugin/task/GenerateJsonSchemaTest.java
@@ -482,9 +482,11 @@ class GenerateJsonSchemaTest {
         }
 
         if (!options.isEmpty()) {
+            // Use forward slashes to avoid backslashes being treated as escape chars in .properties:
+            final String jvmArgs = String.join(" ", options).replace("\\", "/");
             TestPaths.write(
                     projectDir.resolve("gradle.properties"),
-                    "org.gradle.jvmargs=" + String.join(" ", options));
+                    "org.gradle.jvmargs=" + jvmArgs);
         }
     }
 


### PR DESCRIPTION
## Root Cause

On Windows, the `codeCoverageCmdLineArg` utility generates a `-javaagent` JVM argument with Windows-style backslash paths (e.g. `-javaagent:D:\a\...\build\jacoco\jacocoagent.jar=...`).

When `writeGradleProperties()` writes this to `gradle.properties`, Java's `.properties` format treats `\` as an escape character. So `D:\a\build` is read back as `D:abuild`, corrupting the `-javaagent` path and causing the Gradle daemon to fail with:

```
Error opening zip file or JAR manifest missing : D:acreek-json-schema-gradle-plugincreek-json-schema-gradle-pluginbuild
Error occurred during initialization of VM
agent library failed to init: instrument
```

This caused all `shouldExecuteWithSpecificVersion`, `shouldExecuteWithOptions`, and `shouldWriteOutSchemaFilesAsFlatDirectory` tests (and others) to fail on the `build_windows` CI job.

## Fix

Replace backslashes with forward slashes when building the `org.gradle.jvmargs` value before writing to `gradle.properties`. Forward slashes are valid path separators in Java on all platforms, including Windows.

## Tests

Existing functional tests cover this path — the fix allows them to pass on Windows.