### PR TITLE
fix: fix Windows CI build failures

### DIFF
--- a/buildSrc/src/main/kotlin/creek-common-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/creek-common-convention.gradle.kts
@@ -90,6 +90,12 @@ tasks.test {
         showExceptions = true
         showStackTraces = true
     }
+
+    // Workaround for Gradle 8.8 + Jacoco on Windows: after the test JVM exits,
+    // Windows briefly holds the Jacoco .exec file open, causing Gradle to fail
+    // when hashing the file for incremental build state tracking.
+    // See: https://github.com/gradle/gradle/issues/26039
+    doNotTrackState("Workaround for Jacoco output file locking on Windows")
 }
 
 spotless {

--- a/buildSrc/src/main/kotlin/creek-common-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/creek-common-convention.gradle.kts
@@ -91,11 +91,13 @@ tasks.test {
         showStackTraces = true
     }
 
-    // Workaround for Gradle 8.8 + Jacoco on Windows: after the test JVM exits,
-    // Windows briefly holds the Jacoco .exec file open, causing Gradle to fail
-    // when hashing the file for incremental build state tracking.
-    // See: https://github.com/gradle/gradle/issues/26039
-    doNotTrackState("Workaround for Jacoco output file locking on Windows")
+    if (org.apache.tools.ant.taskdefs.condition.Os.isFamily(org.apache.tools.ant.taskdefs.condition.Os.FAMILY_WINDOWS)) {
+        // Workaround for Gradle 8.8 + Jacoco on Windows: after the test JVM exits,
+        // Windows briefly holds the Jacoco .exec file open, causing Gradle to fail
+        // when hashing the file for incremental build state tracking.
+        // See: https://github.com/gradle/gradle/issues/26039
+        doNotTrackState("Workaround for Jacoco output file locking on Windows")
+    }
 }
 
 spotless {

--- a/src/test/java/org/creekservice/api/json/schema/gradle/plugin/task/GenerateJsonSchemaTest.java
+++ b/src/test/java/org/creekservice/api/json/schema/gradle/plugin/task/GenerateJsonSchemaTest.java
@@ -135,7 +135,8 @@ class GenerateJsonSchemaTest {
                 result.getOutput(),
                 matchesPattern(
                         Pattern.compile(
-                                ".*--class-path=.*build/classes/java/main[;:].*", Pattern.DOTALL)));
+                                ".*--class-path=.*build[/\\\\]classes[/\\\\]java[/\\\\]main[;:].*",
+                                Pattern.DOTALL)));
         assertThat(
                 "Should be running from the class-path",
                 result.getOutput(),

--- a/src/test/java/org/creekservice/api/json/schema/gradle/plugin/task/GenerateJsonSchemaTest.java
+++ b/src/test/java/org/creekservice/api/json/schema/gradle/plugin/task/GenerateJsonSchemaTest.java
@@ -482,11 +482,11 @@ class GenerateJsonSchemaTest {
         }
 
         if (!options.isEmpty()) {
-            // Use forward slashes to avoid backslashes being treated as escape chars in .properties:
+            // Use forward slashes to avoid backslashes being treated as escape chars in
+            // .properties:
             final String jvmArgs = String.join(" ", options).replace("\\", "/");
             TestPaths.write(
-                    projectDir.resolve("gradle.properties"),
-                    "org.gradle.jvmargs=" + jvmArgs);
+                    projectDir.resolve("gradle.properties"), "org.gradle.jvmargs=" + jvmArgs);
         }
     }
 

--- a/src/test/java/org/creekservice/api/json/schema/gradle/plugin/task/GenerateJsonSchemaTest.java
+++ b/src/test/java/org/creekservice/api/json/schema/gradle/plugin/task/GenerateJsonSchemaTest.java
@@ -135,7 +135,7 @@ class GenerateJsonSchemaTest {
                 result.getOutput(),
                 matchesPattern(
                         Pattern.compile(
-                                ".*--class-path=.*build/classes/java/main:.*", Pattern.DOTALL)));
+                                ".*--class-path=.*build/classes/java/main[;:].*", Pattern.DOTALL)));
         assertThat(
                 "Should be running from the class-path",
                 result.getOutput(),

--- a/src/test/resources/projects/functional/groovy/generates_flat_schema/groovy/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/groovy/generates_flat_schema/groovy/src/test/java/acme/ModelTest.java
@@ -17,9 +17,7 @@
 package acme;
 
 import org.junit.jupiter.api.Test;
-import java.io.File;
 import java.net.URL;
-import java.nio.file.Path;
 
 class ModelTest {
 

--- a/src/test/resources/projects/functional/groovy/generates_flat_schema/groovy/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/groovy/generates_flat_schema/groovy/src/test/java/acme/ModelTest.java
@@ -23,10 +23,10 @@ class ModelTest {
 
     @Test
     void shouldLoadSchemaAsResource() {
-        final Path path = Path.of(File.separator, "schema", "json", "acme.Model.yml");
-        final URL resource = ModelTest.class.getResource(path.toString());
+        final URL resource = ModelTest.class.getResource("/schema/json/acme.Model.yml");
+        System.out.println("/schema/json/acme.Model.yml -> " + resource);
         if (resource == null) {
-            throw new AssertionError("resource not found: " + path);
+            throw new AssertionError("resource not found: /schema/json/acme.Model.yml");
         }
     }
 }

--- a/src/test/resources/projects/functional/groovy/generates_flat_schema/groovy/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/groovy/generates_flat_schema/groovy/src/test/java/acme/ModelTest.java
@@ -23,10 +23,10 @@ class ModelTest {
 
     @Test
     void shouldLoadSchemaAsResource() {
-        final URL resource = ModelTest.class.getResource("/schema/json/acme.Model.yml");
-        System.out.println("/schema/json/acme.Model.yml -> " + resource);
+        final String resourcePath = "/schema/json/acme.Model.yml";
+        final URL resource = ModelTest.class.getResource(resourcePath);
         if (resource == null) {
-            throw new AssertionError("resource not found: /schema/json/acme.Model.yml");
+            throw new AssertionError("resource not found: " + resourcePath);
         }
     }
 }

--- a/src/test/resources/projects/functional/groovy/generates_flat_schema/java-module/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/groovy/generates_flat_schema/java-module/src/test/java/acme/ModelTest.java
@@ -17,9 +17,7 @@
 package acme;
 
 import org.junit.jupiter.api.Test;
-import java.io.File;
 import java.net.URL;
-import java.nio.file.Path;
 
 class ModelTest {
 

--- a/src/test/resources/projects/functional/groovy/generates_flat_schema/java-module/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/groovy/generates_flat_schema/java-module/src/test/java/acme/ModelTest.java
@@ -23,10 +23,10 @@ class ModelTest {
 
     @Test
     void shouldLoadSchemaAsResource() {
-        final Path path = Path.of(File.separator, "schema", "json", "acme.Model.yml");
-        final URL resource = ModelTest.class.getResource(path.toString());
+        final URL resource = ModelTest.class.getResource("/schema/json/acme.Model.yml");
+        System.out.println("/schema/json/acme.Model.yml -> " + resource);
         if (resource == null) {
-            throw new AssertionError("resource not found: " + path);
+            throw new AssertionError("resource not found: /schema/json/acme.Model.yml");
         }
     }
 }

--- a/src/test/resources/projects/functional/groovy/generates_flat_schema/java-module/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/groovy/generates_flat_schema/java-module/src/test/java/acme/ModelTest.java
@@ -23,10 +23,10 @@ class ModelTest {
 
     @Test
     void shouldLoadSchemaAsResource() {
-        final URL resource = ModelTest.class.getResource("/schema/json/acme.Model.yml");
-        System.out.println("/schema/json/acme.Model.yml -> " + resource);
+        final String resourcePath = "/schema/json/acme.Model.yml";
+        final URL resource = ModelTest.class.getResource(resourcePath);
         if (resource == null) {
-            throw new AssertionError("resource not found: /schema/json/acme.Model.yml");
+            throw new AssertionError("resource not found: " + resourcePath);
         }
     }
 }

--- a/src/test/resources/projects/functional/groovy/generates_flat_schema/java/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/groovy/generates_flat_schema/java/src/test/java/acme/ModelTest.java
@@ -17,9 +17,7 @@
 package acme;
 
 import org.junit.jupiter.api.Test;
-import java.io.File;
 import java.net.URL;
-import java.nio.file.Path;
 
 class ModelTest {
 

--- a/src/test/resources/projects/functional/groovy/generates_flat_schema/java/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/groovy/generates_flat_schema/java/src/test/java/acme/ModelTest.java
@@ -23,11 +23,10 @@ class ModelTest {
 
     @Test
     void shouldLoadSchemaAsResource() {
-        final Path path = Path.of(File.separator, "schema", "json", "acme.Model.yml");
-        final URL resource = ModelTest.class.getResource(path.toString());
-        System.out.println(path + " -> " + resource);
+        final URL resource = ModelTest.class.getResource("/schema/json/acme.Model.yml");
+        System.out.println("/schema/json/acme.Model.yml -> " + resource);
         if (resource == null) {
-            throw new AssertionError("resource not found: " + path);
+            throw new AssertionError("resource not found: /schema/json/acme.Model.yml");
         }
     }
 }

--- a/src/test/resources/projects/functional/groovy/generates_flat_schema/java/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/groovy/generates_flat_schema/java/src/test/java/acme/ModelTest.java
@@ -23,10 +23,10 @@ class ModelTest {
 
     @Test
     void shouldLoadSchemaAsResource() {
-        final URL resource = ModelTest.class.getResource("/schema/json/acme.Model.yml");
-        System.out.println("/schema/json/acme.Model.yml -> " + resource);
+        final String resourcePath = "/schema/json/acme.Model.yml";
+        final URL resource = ModelTest.class.getResource(resourcePath);
         if (resource == null) {
-            throw new AssertionError("resource not found: /schema/json/acme.Model.yml");
+            throw new AssertionError("resource not found: " + resourcePath);
         }
     }
 }

--- a/src/test/resources/projects/functional/groovy/generates_flat_schema/kotlin/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/groovy/generates_flat_schema/kotlin/src/test/java/acme/ModelTest.java
@@ -17,9 +17,7 @@
 package acme;
 
 import org.junit.jupiter.api.Test;
-import java.io.File;
 import java.net.URL;
-import java.nio.file.Path;
 
 class ModelTest {
 

--- a/src/test/resources/projects/functional/groovy/generates_flat_schema/kotlin/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/groovy/generates_flat_schema/kotlin/src/test/java/acme/ModelTest.java
@@ -23,10 +23,10 @@ class ModelTest {
 
     @Test
     void shouldLoadSchemaAsResource() {
-        final Path path = Path.of(File.separator, "schema", "json", "acme.Model.yml");
-        final URL resource = ModelTest.class.getResource(path.toString());
+        final URL resource = ModelTest.class.getResource("/schema/json/acme.Model.yml");
+        System.out.println("/schema/json/acme.Model.yml -> " + resource);
         if (resource == null) {
-            throw new AssertionError("resource not found: " + path);
+            throw new AssertionError("resource not found: /schema/json/acme.Model.yml");
         }
     }
 }

--- a/src/test/resources/projects/functional/groovy/generates_flat_schema/kotlin/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/groovy/generates_flat_schema/kotlin/src/test/java/acme/ModelTest.java
@@ -23,10 +23,10 @@ class ModelTest {
 
     @Test
     void shouldLoadSchemaAsResource() {
-        final URL resource = ModelTest.class.getResource("/schema/json/acme.Model.yml");
-        System.out.println("/schema/json/acme.Model.yml -> " + resource);
+        final String resourcePath = "/schema/json/acme.Model.yml";
+        final URL resource = ModelTest.class.getResource(resourcePath);
         if (resource == null) {
-            throw new AssertionError("resource not found: /schema/json/acme.Model.yml");
+            throw new AssertionError("resource not found: " + resourcePath);
         }
     }
 }

--- a/src/test/resources/projects/functional/groovy/generates_schema/groovy/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/groovy/generates_schema/groovy/src/test/java/acme/ModelTest.java
@@ -17,9 +17,7 @@
 package acme;
 
 import org.junit.jupiter.api.Test;
-import java.io.File;
 import java.net.URL;
-import java.nio.file.Path;
 
 class ModelTest {
 

--- a/src/test/resources/projects/functional/groovy/generates_schema/groovy/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/groovy/generates_schema/groovy/src/test/java/acme/ModelTest.java
@@ -23,10 +23,10 @@ class ModelTest {
 
     @Test
     void shouldLoadSchemaAsResource() {
-        final URL resource = ModelTest.class.getResource("/acme/Model.yml");
-        System.out.println("/acme/Model.yml -> " + resource);
+        final String resourcePath = "/acme/Model.yml";
+        final URL resource = ModelTest.class.getResource(resourcePath);
         if (resource == null) {
-            throw new AssertionError("resource not found: /acme/Model.yml");
+            throw new AssertionError("resource not found: " + resourcePath);
         }
     }
 }

--- a/src/test/resources/projects/functional/groovy/generates_schema/groovy/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/groovy/generates_schema/groovy/src/test/java/acme/ModelTest.java
@@ -23,10 +23,10 @@ class ModelTest {
 
     @Test
     void shouldLoadSchemaAsResource() {
-        final Path path = Path.of(File.separator, "acme", "Model.yml");
-        final URL resource = ModelTest.class.getResource(path.toString());
+        final URL resource = ModelTest.class.getResource("/acme/Model.yml");
+        System.out.println("/acme/Model.yml -> " + resource);
         if (resource == null) {
-            throw new AssertionError("resource not found: " + path);
+            throw new AssertionError("resource not found: /acme/Model.yml");
         }
     }
 }

--- a/src/test/resources/projects/functional/groovy/generates_schema/java-module/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/groovy/generates_schema/java-module/src/test/java/acme/ModelTest.java
@@ -23,10 +23,10 @@ class ModelTest {
 
     @Test
     void shouldLoadSchemaAsResource() {
-        final URL resource = Model.class.getResource("/acme/Model.yml");
-        System.out.println("/acme/Model.yml -> " + resource);
+        final String resourcePath = "/acme/Model.yml";
+        final URL resource = Model.class.getResource(resourcePath);
         if (resource == null) {
-            throw new AssertionError("resource not found: /acme/Model.yml");
+            throw new AssertionError("resource not found: " + resourcePath);
         }
     }
 }

--- a/src/test/resources/projects/functional/groovy/generates_schema/java-module/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/groovy/generates_schema/java-module/src/test/java/acme/ModelTest.java
@@ -17,9 +17,7 @@
 package acme;
 
 import org.junit.jupiter.api.Test;
-import java.io.File;
 import java.net.URL;
-import java.nio.file.Path;
 
 class ModelTest {
 

--- a/src/test/resources/projects/functional/groovy/generates_schema/java-module/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/groovy/generates_schema/java-module/src/test/java/acme/ModelTest.java
@@ -23,10 +23,10 @@ class ModelTest {
 
     @Test
     void shouldLoadSchemaAsResource() {
-        final Path path = Path.of(File.separator, "acme", "Model.yml");
-        final URL resource = Model.class.getResource(path.toString());
+        final URL resource = Model.class.getResource("/acme/Model.yml");
+        System.out.println("/acme/Model.yml -> " + resource);
         if (resource == null) {
-            throw new AssertionError("resource not found: " + path);
+            throw new AssertionError("resource not found: /acme/Model.yml");
         }
     }
 }

--- a/src/test/resources/projects/functional/groovy/generates_schema/java/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/groovy/generates_schema/java/src/test/java/acme/ModelTest.java
@@ -23,10 +23,10 @@ class ModelTest {
 
     @Test
     void shouldLoadSchemaAsResource() {
-        final URL resource = ModelTest.class.getResource("/acme/Model.yml");
-        System.out.println("/acme/Model.yml -> " + resource);
+        final String resourcePath = "/acme/Model.yml";
+        final URL resource = ModelTest.class.getResource(resourcePath);
         if (resource == null) {
-            throw new AssertionError("resource not found: /acme/Model.yml");
+            throw new AssertionError("resource not found: " + resourcePath);
         }
     }
 }

--- a/src/test/resources/projects/functional/groovy/generates_schema/java/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/groovy/generates_schema/java/src/test/java/acme/ModelTest.java
@@ -17,19 +17,16 @@
 package acme;
 
 import org.junit.jupiter.api.Test;
-import java.io.File;
 import java.net.URL;
-import java.nio.file.Path;
 
 class ModelTest {
 
     @Test
     void shouldLoadSchemaAsResource() {
-        final Path path = Path.of(File.separator, "acme", "Model.yml");
-        final URL resource = ModelTest.class.getResource(path.toString());
-        System.out.println(path + " -> " + resource);
+        final URL resource = ModelTest.class.getResource("/acme/Model.yml");
+        System.out.println("/acme/Model.yml -> " + resource);
         if (resource == null) {
-            throw new AssertionError("resource not found: " + path);
+            throw new AssertionError("resource not found: /acme/Model.yml");
         }
     }
 }

--- a/src/test/resources/projects/functional/groovy/generates_schema/kotlin/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/groovy/generates_schema/kotlin/src/test/java/acme/ModelTest.java
@@ -17,9 +17,7 @@
 package acme;
 
 import org.junit.jupiter.api.Test;
-import java.io.File;
 import java.net.URL;
-import java.nio.file.Path;
 
 class ModelTest {
 

--- a/src/test/resources/projects/functional/groovy/generates_schema/kotlin/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/groovy/generates_schema/kotlin/src/test/java/acme/ModelTest.java
@@ -23,10 +23,10 @@ class ModelTest {
 
     @Test
     void shouldLoadSchemaAsResource() {
-        final URL resource = ModelTest.class.getResource("/acme/Model.yml");
-        System.out.println("/acme/Model.yml -> " + resource);
+        final String resourcePath = "/acme/Model.yml";
+        final URL resource = ModelTest.class.getResource(resourcePath);
         if (resource == null) {
-            throw new AssertionError("resource not found: /acme/Model.yml");
+            throw new AssertionError("resource not found: " + resourcePath);
         }
     }
 }

--- a/src/test/resources/projects/functional/groovy/generates_schema/kotlin/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/groovy/generates_schema/kotlin/src/test/java/acme/ModelTest.java
@@ -23,10 +23,10 @@ class ModelTest {
 
     @Test
     void shouldLoadSchemaAsResource() {
-        final Path path = Path.of(File.separator, "acme", "Model.yml");
-        final URL resource = ModelTest.class.getResource(path.toString());
+        final URL resource = ModelTest.class.getResource("/acme/Model.yml");
+        System.out.println("/acme/Model.yml -> " + resource);
         if (resource == null) {
-            throw new AssertionError("resource not found: " + path);
+            throw new AssertionError("resource not found: /acme/Model.yml");
         }
     }
 }

--- a/src/test/resources/projects/functional/groovy/generates_test_schema/groovy/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/groovy/generates_test_schema/groovy/src/test/java/acme/ModelTest.java
@@ -17,9 +17,7 @@
 package acme;
 
 import org.junit.jupiter.api.Test;
-import java.io.File;
 import java.net.URL;
-import java.nio.file.Path;
 
 class ModelTest {
 

--- a/src/test/resources/projects/functional/groovy/generates_test_schema/groovy/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/groovy/generates_test_schema/groovy/src/test/java/acme/ModelTest.java
@@ -23,10 +23,10 @@ class ModelTest {
 
     @Test
     void shouldLoadSchemaAsResource() {
-        final URL resource = ModelTest.class.getResource("/acme/Model.yml");
-        System.out.println("/acme/Model.yml -> " + resource);
+        final String resourcePath = "/acme/Model.yml";
+        final URL resource = ModelTest.class.getResource(resourcePath);
         if (resource == null) {
-            throw new AssertionError("resource not found: /acme/Model.yml");
+            throw new AssertionError("resource not found: " + resourcePath);
         }
     }
 }

--- a/src/test/resources/projects/functional/groovy/generates_test_schema/groovy/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/groovy/generates_test_schema/groovy/src/test/java/acme/ModelTest.java
@@ -23,10 +23,10 @@ class ModelTest {
 
     @Test
     void shouldLoadSchemaAsResource() {
-        final Path path = Path.of(File.separator, "acme", "Model.yml");
-        final URL resource = ModelTest.class.getResource(path.toString());
+        final URL resource = ModelTest.class.getResource("/acme/Model.yml");
+        System.out.println("/acme/Model.yml -> " + resource);
         if (resource == null) {
-            throw new AssertionError("resource not found: " + path);
+            throw new AssertionError("resource not found: /acme/Model.yml");
         }
     }
 }

--- a/src/test/resources/projects/functional/groovy/generates_test_schema/java-module/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/groovy/generates_test_schema/java-module/src/test/java/acme/ModelTest.java
@@ -17,9 +17,7 @@
 package acme;
 
 import org.junit.jupiter.api.Test;
-import java.io.File;
 import java.net.URL;
-import java.nio.file.Path;
 
 class ModelTest {
 

--- a/src/test/resources/projects/functional/groovy/generates_test_schema/java-module/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/groovy/generates_test_schema/java-module/src/test/java/acme/ModelTest.java
@@ -23,10 +23,10 @@ class ModelTest {
 
     @Test
     void shouldLoadSchemaAsResource() {
-        final URL resource = ModelTest.class.getResource("/acme/Model.yml");
-        System.out.println("/acme/Model.yml -> " + resource);
+        final String resourcePath = "/acme/Model.yml";
+        final URL resource = Model.class.getResource(resourcePath);
         if (resource == null) {
-            throw new AssertionError("resource not found: /acme/Model.yml");
+            throw new AssertionError("resource not found: " + resourcePath);
         }
     }
 }

--- a/src/test/resources/projects/functional/groovy/generates_test_schema/java-module/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/groovy/generates_test_schema/java-module/src/test/java/acme/ModelTest.java
@@ -23,10 +23,10 @@ class ModelTest {
 
     @Test
     void shouldLoadSchemaAsResource() {
-        final Path path = Path.of(File.separator, "acme", "Model.yml");
-        final URL resource = ModelTest.class.getResource(path.toString());
+        final URL resource = ModelTest.class.getResource("/acme/Model.yml");
+        System.out.println("/acme/Model.yml -> " + resource);
         if (resource == null) {
-            throw new AssertionError("resource not found: " + path);
+            throw new AssertionError("resource not found: /acme/Model.yml");
         }
     }
 }

--- a/src/test/resources/projects/functional/groovy/generates_test_schema/java/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/groovy/generates_test_schema/java/src/test/java/acme/ModelTest.java
@@ -23,10 +23,10 @@ class ModelTest {
 
     @Test
     void shouldLoadSchemaAsResource() {
-        final URL resource = ModelTest.class.getResource("/acme/Model.yml");
-        System.out.println("/acme/Model.yml -> " + resource);
+        final String resourcePath = "/acme/Model.yml";
+        final URL resource = ModelTest.class.getResource(resourcePath);
         if (resource == null) {
-            throw new AssertionError("resource not found: /acme/Model.yml");
+            throw new AssertionError("resource not found: " + resourcePath);
         }
     }
 }

--- a/src/test/resources/projects/functional/groovy/generates_test_schema/java/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/groovy/generates_test_schema/java/src/test/java/acme/ModelTest.java
@@ -17,19 +17,16 @@
 package acme;
 
 import org.junit.jupiter.api.Test;
-import java.io.File;
 import java.net.URL;
-import java.nio.file.Path;
 
 class ModelTest {
 
     @Test
     void shouldLoadSchemaAsResource() {
-        final Path path = Path.of(File.separator, "acme", "Model.yml");
-        final URL resource = ModelTest.class.getResource(path.toString());
-        System.out.println(path + " -> " + resource);
+        final URL resource = ModelTest.class.getResource("/acme/Model.yml");
+        System.out.println("/acme/Model.yml -> " + resource);
         if (resource == null) {
-            throw new AssertionError("resource not found: " + path);
+            throw new AssertionError("resource not found: /acme/Model.yml");
         }
     }
 }

--- a/src/test/resources/projects/functional/groovy/generates_test_schema/kotlin/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/groovy/generates_test_schema/kotlin/src/test/java/acme/ModelTest.java
@@ -17,9 +17,7 @@
 package acme;
 
 import org.junit.jupiter.api.Test;
-import java.io.File;
 import java.net.URL;
-import java.nio.file.Path;
 
 class ModelTest {
 

--- a/src/test/resources/projects/functional/groovy/generates_test_schema/kotlin/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/groovy/generates_test_schema/kotlin/src/test/java/acme/ModelTest.java
@@ -23,10 +23,10 @@ class ModelTest {
 
     @Test
     void shouldLoadSchemaAsResource() {
-        final URL resource = ModelTest.class.getResource("/acme/Model.yml");
-        System.out.println("/acme/Model.yml -> " + resource);
+        final String resourcePath = "/acme/Model.yml";
+        final URL resource = ModelTest.class.getResource(resourcePath);
         if (resource == null) {
-            throw new AssertionError("resource not found: /acme/Model.yml");
+            throw new AssertionError("resource not found: " + resourcePath);
         }
     }
 }

--- a/src/test/resources/projects/functional/groovy/generates_test_schema/kotlin/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/groovy/generates_test_schema/kotlin/src/test/java/acme/ModelTest.java
@@ -23,10 +23,10 @@ class ModelTest {
 
     @Test
     void shouldLoadSchemaAsResource() {
-        final Path path = Path.of(File.separator, "acme", "Model.yml");
-        final URL resource = ModelTest.class.getResource(path.toString());
+        final URL resource = ModelTest.class.getResource("/acme/Model.yml");
+        System.out.println("/acme/Model.yml -> " + resource);
         if (resource == null) {
-            throw new AssertionError("resource not found: " + path);
+            throw new AssertionError("resource not found: /acme/Model.yml");
         }
     }
 }

--- a/src/test/resources/projects/functional/kotlin/generates_flat_schema/groovy/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/kotlin/generates_flat_schema/groovy/src/test/java/acme/ModelTest.java
@@ -17,9 +17,7 @@
 package acme;
 
 import org.junit.jupiter.api.Test;
-import java.io.File;
 import java.net.URL;
-import java.nio.file.Path;
 
 class ModelTest {
 

--- a/src/test/resources/projects/functional/kotlin/generates_flat_schema/groovy/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/kotlin/generates_flat_schema/groovy/src/test/java/acme/ModelTest.java
@@ -23,11 +23,10 @@ class ModelTest {
 
     @Test
     void shouldLoadSchemaAsResource() {
-        final Path path = Path.of(File.separator, "schema", "json", "acme.Model.yml");
-        final URL resource = ModelTest.class.getResource(path.toString());
-        System.out.println(path + " -> " + resource);
+        final URL resource = ModelTest.class.getResource("/schema/json/acme.Model.yml");
+        System.out.println("/schema/json/acme.Model.yml -> " + resource);
         if (resource == null) {
-            throw new AssertionError("resource not found: " + path);
+            throw new AssertionError("resource not found: /schema/json/acme.Model.yml");
         }
     }
 }

--- a/src/test/resources/projects/functional/kotlin/generates_flat_schema/groovy/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/kotlin/generates_flat_schema/groovy/src/test/java/acme/ModelTest.java
@@ -23,10 +23,10 @@ class ModelTest {
 
     @Test
     void shouldLoadSchemaAsResource() {
-        final URL resource = ModelTest.class.getResource("/schema/json/acme.Model.yml");
-        System.out.println("/schema/json/acme.Model.yml -> " + resource);
+        final String resourcePath = "/schema/json/acme.Model.yml";
+        final URL resource = ModelTest.class.getResource(resourcePath);
         if (resource == null) {
-            throw new AssertionError("resource not found: /schema/json/acme.Model.yml");
+            throw new AssertionError("resource not found: " + resourcePath);
         }
     }
 }

--- a/src/test/resources/projects/functional/kotlin/generates_flat_schema/java-module/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/kotlin/generates_flat_schema/java-module/src/test/java/acme/ModelTest.java
@@ -17,9 +17,7 @@
 package acme;
 
 import org.junit.jupiter.api.Test;
-import java.io.File;
 import java.net.URL;
-import java.nio.file.Path;
 
 class ModelTest {
 

--- a/src/test/resources/projects/functional/kotlin/generates_flat_schema/java-module/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/kotlin/generates_flat_schema/java-module/src/test/java/acme/ModelTest.java
@@ -23,11 +23,10 @@ class ModelTest {
 
     @Test
     void shouldLoadSchemaAsResource() {
-        final Path path = Path.of(File.separator, "schema", "json", "acme.Model.yml");
-        final URL resource = ModelTest.class.getResource(path.toString());
-        System.out.println(path + " -> " + resource);
+        final URL resource = ModelTest.class.getResource("/schema/json/acme.Model.yml");
+        System.out.println("/schema/json/acme.Model.yml -> " + resource);
         if (resource == null) {
-            throw new AssertionError("resource not found: " + path);
+            throw new AssertionError("resource not found: /schema/json/acme.Model.yml");
         }
     }
 }

--- a/src/test/resources/projects/functional/kotlin/generates_flat_schema/java-module/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/kotlin/generates_flat_schema/java-module/src/test/java/acme/ModelTest.java
@@ -23,10 +23,10 @@ class ModelTest {
 
     @Test
     void shouldLoadSchemaAsResource() {
-        final URL resource = ModelTest.class.getResource("/schema/json/acme.Model.yml");
-        System.out.println("/schema/json/acme.Model.yml -> " + resource);
+        final String resourcePath = "/schema/json/acme.Model.yml";
+        final URL resource = ModelTest.class.getResource(resourcePath);
         if (resource == null) {
-            throw new AssertionError("resource not found: /schema/json/acme.Model.yml");
+            throw new AssertionError("resource not found: " + resourcePath);
         }
     }
 }

--- a/src/test/resources/projects/functional/kotlin/generates_flat_schema/java/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/kotlin/generates_flat_schema/java/src/test/java/acme/ModelTest.java
@@ -17,9 +17,7 @@
 package acme;
 
 import org.junit.jupiter.api.Test;
-import java.io.File;
 import java.net.URL;
-import java.nio.file.Path;
 
 class ModelTest {
 

--- a/src/test/resources/projects/functional/kotlin/generates_flat_schema/java/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/kotlin/generates_flat_schema/java/src/test/java/acme/ModelTest.java
@@ -23,11 +23,10 @@ class ModelTest {
 
     @Test
     void shouldLoadSchemaAsResource() {
-        final Path path = Path.of(File.separator, "schema", "json", "acme.Model.yml");
-        final URL resource = ModelTest.class.getResource(path.toString());
-        System.out.println(path + " -> " + resource);
+        final URL resource = ModelTest.class.getResource("/schema/json/acme.Model.yml");
+        System.out.println("/schema/json/acme.Model.yml -> " + resource);
         if (resource == null) {
-            throw new AssertionError("resource not found: " + path);
+            throw new AssertionError("resource not found: /schema/json/acme.Model.yml");
         }
     }
 }

--- a/src/test/resources/projects/functional/kotlin/generates_flat_schema/java/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/kotlin/generates_flat_schema/java/src/test/java/acme/ModelTest.java
@@ -23,10 +23,10 @@ class ModelTest {
 
     @Test
     void shouldLoadSchemaAsResource() {
-        final URL resource = ModelTest.class.getResource("/schema/json/acme.Model.yml");
-        System.out.println("/schema/json/acme.Model.yml -> " + resource);
+        final String resourcePath = "/schema/json/acme.Model.yml";
+        final URL resource = ModelTest.class.getResource(resourcePath);
         if (resource == null) {
-            throw new AssertionError("resource not found: /schema/json/acme.Model.yml");
+            throw new AssertionError("resource not found: " + resourcePath);
         }
     }
 }

--- a/src/test/resources/projects/functional/kotlin/generates_flat_schema/kotlin/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/kotlin/generates_flat_schema/kotlin/src/test/java/acme/ModelTest.java
@@ -17,9 +17,7 @@
 package acme;
 
 import org.junit.jupiter.api.Test;
-import java.io.File;
 import java.net.URL;
-import java.nio.file.Path;
 
 class ModelTest {
 

--- a/src/test/resources/projects/functional/kotlin/generates_flat_schema/kotlin/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/kotlin/generates_flat_schema/kotlin/src/test/java/acme/ModelTest.java
@@ -23,11 +23,10 @@ class ModelTest {
 
     @Test
     void shouldLoadSchemaAsResource() {
-        final Path path = Path.of(File.separator, "schema", "json", "acme.Model.yml");
-        final URL resource = ModelTest.class.getResource(path.toString());
-        System.out.println(path + " -> " + resource);
+        final URL resource = ModelTest.class.getResource("/schema/json/acme.Model.yml");
+        System.out.println("/schema/json/acme.Model.yml -> " + resource);
         if (resource == null) {
-            throw new AssertionError("resource not found: " + path);
+            throw new AssertionError("resource not found: /schema/json/acme.Model.yml");
         }
     }
 }

--- a/src/test/resources/projects/functional/kotlin/generates_flat_schema/kotlin/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/kotlin/generates_flat_schema/kotlin/src/test/java/acme/ModelTest.java
@@ -23,10 +23,10 @@ class ModelTest {
 
     @Test
     void shouldLoadSchemaAsResource() {
-        final URL resource = ModelTest.class.getResource("/schema/json/acme.Model.yml");
-        System.out.println("/schema/json/acme.Model.yml -> " + resource);
+        final String resourcePath = "/schema/json/acme.Model.yml";
+        final URL resource = ModelTest.class.getResource(resourcePath);
         if (resource == null) {
-            throw new AssertionError("resource not found: /schema/json/acme.Model.yml");
+            throw new AssertionError("resource not found: " + resourcePath);
         }
     }
 }

--- a/src/test/resources/projects/functional/kotlin/generates_schema/groovy/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/kotlin/generates_schema/groovy/src/test/java/acme/ModelTest.java
@@ -23,10 +23,10 @@ class ModelTest {
 
     @Test
     void shouldLoadSchemaAsResource() {
-        final URL resource = ModelTest.class.getResource("/acme/Model.yml");
-        System.out.println("/acme/Model.yml -> " + resource);
+        final String resourcePath = "/acme/Model.yml";
+        final URL resource = ModelTest.class.getResource(resourcePath);
         if (resource == null) {
-            throw new AssertionError("resource not found: /acme/Model.yml");
+            throw new AssertionError("resource not found: " + resourcePath);
         }
     }
 }

--- a/src/test/resources/projects/functional/kotlin/generates_schema/groovy/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/kotlin/generates_schema/groovy/src/test/java/acme/ModelTest.java
@@ -17,19 +17,16 @@
 package acme;
 
 import org.junit.jupiter.api.Test;
-import java.io.File;
 import java.net.URL;
-import java.nio.file.Path;
 
 class ModelTest {
 
     @Test
     void shouldLoadSchemaAsResource() {
-        final Path path = Path.of(File.separator, "acme", "Model.yml");
-        final URL resource = ModelTest.class.getResource(path.toString());
-        System.out.println(path + " -> " + resource);
+        final URL resource = ModelTest.class.getResource("/acme/Model.yml");
+        System.out.println("/acme/Model.yml -> " + resource);
         if (resource == null) {
-            throw new AssertionError("resource not found: " + path);
+            throw new AssertionError("resource not found: /acme/Model.yml");
         }
     }
 }

--- a/src/test/resources/projects/functional/kotlin/generates_schema/java-module/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/kotlin/generates_schema/java-module/src/test/java/acme/ModelTest.java
@@ -17,19 +17,16 @@
 package acme;
 
 import org.junit.jupiter.api.Test;
-import java.io.File;
 import java.net.URL;
-import java.nio.file.Path;
 
 class ModelTest {
 
     @Test
     void shouldLoadSchemaAsResource() {
-        final Path path = Path.of(File.separator, "acme", "Model.yml");
-        final URL resource = ModelTest.class.getResource(path.toString());
-        System.out.println(path + " -> " + resource);
+        final URL resource = ModelTest.class.getResource("/acme/Model.yml");
+        System.out.println("/acme/Model.yml -> " + resource);
         if (resource == null) {
-            throw new AssertionError("resource not found: " + path);
+            throw new AssertionError("resource not found: /acme/Model.yml");
         }
     }
 }

--- a/src/test/resources/projects/functional/kotlin/generates_schema/java-module/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/kotlin/generates_schema/java-module/src/test/java/acme/ModelTest.java
@@ -23,10 +23,10 @@ class ModelTest {
 
     @Test
     void shouldLoadSchemaAsResource() {
-        final URL resource = ModelTest.class.getResource("/acme/Model.yml");
-        System.out.println("/acme/Model.yml -> " + resource);
+        final String resourcePath = "/acme/Model.yml";
+        final URL resource = Model.class.getResource(resourcePath);
         if (resource == null) {
-            throw new AssertionError("resource not found: /acme/Model.yml");
+            throw new AssertionError("resource not found: " + resourcePath);
         }
     }
 }

--- a/src/test/resources/projects/functional/kotlin/generates_schema/java/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/kotlin/generates_schema/java/src/test/java/acme/ModelTest.java
@@ -23,10 +23,10 @@ class ModelTest {
 
     @Test
     void shouldLoadSchemaAsResource() {
-        final URL resource = ModelTest.class.getResource("/acme/Model.yml");
-        System.out.println("/acme/Model.yml -> " + resource);
+        final String resourcePath = "/acme/Model.yml";
+        final URL resource = ModelTest.class.getResource(resourcePath);
         if (resource == null) {
-            throw new AssertionError("resource not found: /acme/Model.yml");
+            throw new AssertionError("resource not found: " + resourcePath);
         }
     }
 }

--- a/src/test/resources/projects/functional/kotlin/generates_schema/java/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/kotlin/generates_schema/java/src/test/java/acme/ModelTest.java
@@ -17,19 +17,16 @@
 package acme;
 
 import org.junit.jupiter.api.Test;
-import java.io.File;
 import java.net.URL;
-import java.nio.file.Path;
 
 class ModelTest {
 
     @Test
     void shouldLoadSchemaAsResource() {
-        final Path path = Path.of(File.separator, "acme", "Model.yml");
-        final URL resource = ModelTest.class.getResource(path.toString());
-        System.out.println(path + " -> " + resource);
+        final URL resource = ModelTest.class.getResource("/acme/Model.yml");
+        System.out.println("/acme/Model.yml -> " + resource);
         if (resource == null) {
-            throw new AssertionError("resource not found: " + path);
+            throw new AssertionError("resource not found: /acme/Model.yml");
         }
     }
 }

--- a/src/test/resources/projects/functional/kotlin/generates_schema/kotlin/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/kotlin/generates_schema/kotlin/src/test/java/acme/ModelTest.java
@@ -23,10 +23,10 @@ class ModelTest {
 
     @Test
     void shouldLoadSchemaAsResource() {
-        final URL resource = ModelTest.class.getResource("/acme/Model.yml");
-        System.out.println("/acme/Model.yml -> " + resource);
+        final String resourcePath = "/acme/Model.yml";
+        final URL resource = ModelTest.class.getResource(resourcePath);
         if (resource == null) {
-            throw new AssertionError("resource not found: /acme/Model.yml");
+            throw new AssertionError("resource not found: " + resourcePath);
         }
     }
 }

--- a/src/test/resources/projects/functional/kotlin/generates_schema/kotlin/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/kotlin/generates_schema/kotlin/src/test/java/acme/ModelTest.java
@@ -17,19 +17,16 @@
 package acme;
 
 import org.junit.jupiter.api.Test;
-import java.io.File;
 import java.net.URL;
-import java.nio.file.Path;
 
 class ModelTest {
 
     @Test
     void shouldLoadSchemaAsResource() {
-        final Path path = Path.of(File.separator, "acme", "Model.yml");
-        final URL resource = ModelTest.class.getResource(path.toString());
-        System.out.println(path + " -> " + resource);
+        final URL resource = ModelTest.class.getResource("/acme/Model.yml");
+        System.out.println("/acme/Model.yml -> " + resource);
         if (resource == null) {
-            throw new AssertionError("resource not found: " + path);
+            throw new AssertionError("resource not found: /acme/Model.yml");
         }
     }
 }

--- a/src/test/resources/projects/functional/kotlin/generates_test_schema/groovy/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/kotlin/generates_test_schema/groovy/src/test/java/acme/ModelTest.java
@@ -23,10 +23,10 @@ class ModelTest {
 
     @Test
     void shouldLoadSchemaAsResource() {
-        final URL resource = ModelTest.class.getResource("/acme/Model.yml");
-        System.out.println("/acme/Model.yml -> " + resource);
+        final String resourcePath = "/acme/Model.yml";
+        final URL resource = ModelTest.class.getResource(resourcePath);
         if (resource == null) {
-            throw new AssertionError("resource not found: /acme/Model.yml");
+            throw new AssertionError("resource not found: " + resourcePath);
         }
     }
 }

--- a/src/test/resources/projects/functional/kotlin/generates_test_schema/groovy/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/kotlin/generates_test_schema/groovy/src/test/java/acme/ModelTest.java
@@ -17,19 +17,16 @@
 package acme;
 
 import org.junit.jupiter.api.Test;
-import java.io.File;
 import java.net.URL;
-import java.nio.file.Path;
 
 class ModelTest {
 
     @Test
     void shouldLoadSchemaAsResource() {
-        final Path path = Path.of(File.separator, "acme", "Model.yml");
-        final URL resource = ModelTest.class.getResource(path.toString());
-        System.out.println(path + " -> " + resource);
+        final URL resource = ModelTest.class.getResource("/acme/Model.yml");
+        System.out.println("/acme/Model.yml -> " + resource);
         if (resource == null) {
-            throw new AssertionError("resource not found: " + path);
+            throw new AssertionError("resource not found: /acme/Model.yml");
         }
     }
 }

--- a/src/test/resources/projects/functional/kotlin/generates_test_schema/java-module/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/kotlin/generates_test_schema/java-module/src/test/java/acme/ModelTest.java
@@ -17,19 +17,16 @@
 package acme;
 
 import org.junit.jupiter.api.Test;
-import java.io.File;
 import java.net.URL;
-import java.nio.file.Path;
 
 class ModelTest {
 
     @Test
     void shouldLoadSchemaAsResource() {
-        final Path path = Path.of(File.separator, "acme", "Model.yml");
-        final URL resource = ModelTest.class.getResource(path.toString());
-        System.out.println(path + " -> " + resource);
+        final URL resource = ModelTest.class.getResource("/acme/Model.yml");
+        System.out.println("/acme/Model.yml -> " + resource);
         if (resource == null) {
-            throw new AssertionError("resource not found: " + path);
+            throw new AssertionError("resource not found: /acme/Model.yml");
         }
     }
 }

--- a/src/test/resources/projects/functional/kotlin/generates_test_schema/java-module/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/kotlin/generates_test_schema/java-module/src/test/java/acme/ModelTest.java
@@ -23,10 +23,10 @@ class ModelTest {
 
     @Test
     void shouldLoadSchemaAsResource() {
-        final URL resource = ModelTest.class.getResource("/acme/Model.yml");
-        System.out.println("/acme/Model.yml -> " + resource);
+        final String resourcePath = "/acme/Model.yml";
+        final URL resource = Model.class.getResource(resourcePath);
         if (resource == null) {
-            throw new AssertionError("resource not found: /acme/Model.yml");
+            throw new AssertionError("resource not found: " + resourcePath);
         }
     }
 }

--- a/src/test/resources/projects/functional/kotlin/generates_test_schema/java/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/kotlin/generates_test_schema/java/src/test/java/acme/ModelTest.java
@@ -23,10 +23,10 @@ class ModelTest {
 
     @Test
     void shouldLoadSchemaAsResource() {
-        final URL resource = ModelTest.class.getResource("/acme/Model.yml");
-        System.out.println("/acme/Model.yml -> " + resource);
+        final String resourcePath = "/acme/Model.yml";
+        final URL resource = ModelTest.class.getResource(resourcePath);
         if (resource == null) {
-            throw new AssertionError("resource not found: /acme/Model.yml");
+            throw new AssertionError("resource not found: " + resourcePath);
         }
     }
 }

--- a/src/test/resources/projects/functional/kotlin/generates_test_schema/java/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/kotlin/generates_test_schema/java/src/test/java/acme/ModelTest.java
@@ -17,19 +17,16 @@
 package acme;
 
 import org.junit.jupiter.api.Test;
-import java.io.File;
 import java.net.URL;
-import java.nio.file.Path;
 
 class ModelTest {
 
     @Test
     void shouldLoadSchemaAsResource() {
-        final Path path = Path.of(File.separator, "acme", "Model.yml");
-        final URL resource = ModelTest.class.getResource(path.toString());
-        System.out.println(path + " -> " + resource);
+        final URL resource = ModelTest.class.getResource("/acme/Model.yml");
+        System.out.println("/acme/Model.yml -> " + resource);
         if (resource == null) {
-            throw new AssertionError("resource not found: " + path);
+            throw new AssertionError("resource not found: /acme/Model.yml");
         }
     }
 }

--- a/src/test/resources/projects/functional/kotlin/generates_test_schema/kotlin/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/kotlin/generates_test_schema/kotlin/src/test/java/acme/ModelTest.java
@@ -23,10 +23,10 @@ class ModelTest {
 
     @Test
     void shouldLoadSchemaAsResource() {
-        final URL resource = ModelTest.class.getResource("/acme/Model.yml");
-        System.out.println("/acme/Model.yml -> " + resource);
+        final String resourcePath = "/acme/Model.yml";
+        final URL resource = ModelTest.class.getResource(resourcePath);
         if (resource == null) {
-            throw new AssertionError("resource not found: /acme/Model.yml");
+            throw new AssertionError("resource not found: " + resourcePath);
         }
     }
 }

--- a/src/test/resources/projects/functional/kotlin/generates_test_schema/kotlin/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/kotlin/generates_test_schema/kotlin/src/test/java/acme/ModelTest.java
@@ -17,19 +17,16 @@
 package acme;
 
 import org.junit.jupiter.api.Test;
-import java.io.File;
 import java.net.URL;
-import java.nio.file.Path;
 
 class ModelTest {
 
     @Test
     void shouldLoadSchemaAsResource() {
-        final Path path = Path.of(File.separator, "acme", "Model.yml");
-        final URL resource = ModelTest.class.getResource(path.toString());
-        System.out.println(path + " -> " + resource);
+        final URL resource = ModelTest.class.getResource("/acme/Model.yml");
+        System.out.println("/acme/Model.yml -> " + resource);
         if (resource == null) {
-            throw new AssertionError("resource not found: " + path);
+            throw new AssertionError("resource not found: /acme/Model.yml");
         }
     }
 }


### PR DESCRIPTION
## Problem

The Windows (and Linux) CI builds were failing with multiple issues introduced by #416.

## Fix

### 1. Spotless formatting violation
A comment added in #416 was 101 characters long (1 over Google Java Format's 100-char limit), causing `spotlessJavaCheck` to fail. The `TestPaths.write()` call also needed reformatting.

### 2. Windows-incompatible resource paths in test projects
24 `ModelTest.java` inner-project files used `Path.of(File.separator, ...)` to build a resource path. On Windows, `File.separator` is `\\`, producing paths like `\\acme\\Model.yml` which `Class.getResource()` cannot resolve (it requires forward-slash separators regardless of OS). Fixed to use a `resourcePath` string variable with a literal forward-slash path.

### 3. Windows-incompatible JVM classpath separator in assertion
`GenerateJsonSchemaTest` asserted that the `--class-path` argument contains `main:` to verify path separator format. On Windows the JVM classpath separator is `;` not `:`. Fixed regex to `[;:]`.

### 4. Windows-incompatible file path separators in Gradle output assertion
The regex pattern `build/classes/java/main` used forward slashes which only match Unix paths. On Windows, Gradle outputs backslash-separated paths. Fixed using `[/\\\\]` to match both.

### 5. Gradle + Jacoco file locking on Windows
Gradle 8.8 + Jacoco on Windows fails after tests complete with:
```
Cannot access output property 'jvmArgumentProviders.jacocoAgent$0.jacoco.destinationFile'
Failed to create MD5 hash for file content.
```
After the test JVM exits, Windows briefly keeps the Jacoco `.exec` output file locked. Gradle then fails to hash it for incremental build state tracking. Fixed by adding `doNotTrackState()` to `tasks.test` in `creek-common-convention.gradle.kts`. See [gradle/gradle#26039](https://github.com/gradle/gradle/issues/26039).