### PR TITLE
fix: replace deprecated Project.javaexec() with injected ExecOperations

### DIFF
--- a/src/main/java/org/creekservice/api/json/schema/gradle/plugin/task/GenerateJsonSchema.java
+++ b/src/main/java/org/creekservice/api/json/schema/gradle/plugin/task/GenerateJsonSchema.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Callable;
+import javax.inject.Inject;
 import org.creekservice.api.json.schema.gradle.plugin.JsonSchemaPlugin;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
@@ -39,15 +40,22 @@ import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.options.Option;
+import org.gradle.process.ExecOperations;
 
 /** Task for generating JSON schemas from code */
 public abstract class GenerateJsonSchema extends DefaultTask {
 
+    private final ExecOperations execOps;
     final ConfigurableFileCollection classPath = getProject().getObjects().fileCollection();
 
-    /** Constructor */
-    public GenerateJsonSchema() {
-
+    /**
+     * Constructor
+     *
+     * @param execOps Gradle exec operations service for executing JVM processes.
+     */
+    @Inject
+    public GenerateJsonSchema(final ExecOperations execOps) {
+        this.execOps = execOps;
         classPath.from((Callable<Object>) this::getClassFiles);
         classPath.from((Callable<Object>) this::getGeneratorDeps);
         classPath.from((Callable<Object>) this::getProjectDeps);
@@ -262,18 +270,16 @@ public abstract class GenerateJsonSchema extends DefaultTask {
         getLogger().info("classpath:");
         classPath.forEach(f -> getLogger().info(f.getAbsolutePath()));
 
-        getProject()
-                .javaexec(
-                        spec -> {
-                            spec.getMainClass()
-                                    .set(
-                                            "org.creekservice.api.json.schema.generator.JsonSchemaGenerator");
-                            spec.getMainModule().set("creek.json.schema.generator");
-                            spec.getModularity().getInferModulePath().set(useModulePath);
-                            spec.setClasspath(classPath);
-                            spec.setArgs(arguments);
-                            spec.jvmArgs(jvmArgs);
-                        });
+        execOps.javaexec(
+                spec -> {
+                    spec.getMainClass()
+                            .set("org.creekservice.api.json.schema.generator.JsonSchemaGenerator");
+                    spec.getMainModule().set("creek.json.schema.generator");
+                    spec.getModularity().getInferModulePath().set(useModulePath);
+                    spec.setClasspath(classPath);
+                    spec.setArgs(arguments);
+                    spec.jvmArgs(jvmArgs);
+                });
     }
 
     private boolean useModulePath() {


### PR DESCRIPTION
## Problem

Gradle 9 removed `Project.javaexec()` (deprecated since Gradle 7.6). The `GenerateJsonSchema` task was calling `getProject().javaexec(...)` in its `@TaskAction` method, which breaks on Gradle 9+.

## Fix

Inject `ExecOperations` into the task class via `@Inject` on the constructor, store it as a private final field, and replace `getProject().javaexec(...)` with `execOps.javaexec(...)`.

This is the recommended Gradle migration path per the [Gradle 9 upgrade guide](https://docs.gradle.org/current/userguide/upgrading_version_8.html).

## Changes

- Add `import javax.inject.Inject;` and `import org.gradle.process.ExecOperations;`
- Add `private final ExecOperations execOps;` field
- Annotate constructor with `@Inject` and inject `ExecOperations execOps` parameter
- Replace `getProject().javaexec(...)` with `execOps.javaexec(...)`

## Verification

Build passes locally: `./gradlew build` (all 89+ tests pass).