### PR TITLE
chore: update copyright year to 2026

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2025-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/creek-common-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/creek-common-convention.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/creek-coverage-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/creek-coverage-convention.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/creek-module-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/creek-module-convention.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/creek-plugin-publishing-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/creek-plugin-publishing-convention.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/creek-publishing-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/creek-publishing-convention.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/creek-sonatype-publishing-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/creek-sonatype-publishing-convention.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+  ~ Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -107,7 +107,7 @@
   <!-- See https://checkstyle.org/config_header.html   -->
   <module name="RegexpHeader">
     <property name="header"
-            value="/\*\n\* Copyright (\d\d\d\d-)?2025 Creek Contributors \(https://github.com/creek-service\)$\n \*$\n \* Licensed under the Apache License, Version 2.0"/>
+            value="/\*\n\* Copyright (\d\d\d\d-)?2026 Creek Contributors \(https://github.com/creek-service\)$\n \*$\n \* Licensed under the Apache License, Version 2.0"/>
   </module>
 
   <module name="TreeWalker">

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  ~ Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+  ~ Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/config/spotbugs/suppressions.xml
+++ b/config/spotbugs/suppressions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2025 Creek Contributors (https://github.com/creek-service)
+  ~ Copyright 2025-2026 Creek Contributors (https://github.com/creek-service)
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/src/main/java/org/creekservice/api/json/schema/gradle/plugin/GeneratorVersion.java
+++ b/src/main/java/org/creekservice/api/json/schema/gradle/plugin/GeneratorVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/creekservice/api/json/schema/gradle/plugin/JsonSchemaExtension.java
+++ b/src/main/java/org/creekservice/api/json/schema/gradle/plugin/JsonSchemaExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/creekservice/api/json/schema/gradle/plugin/JsonSchemaPlugin.java
+++ b/src/main/java/org/creekservice/api/json/schema/gradle/plugin/JsonSchemaPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/creekservice/api/json/schema/gradle/plugin/task/GenerateJsonSchema.java
+++ b/src/main/java/org/creekservice/api/json/schema/gradle/plugin/task/GenerateJsonSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/creekservice/ModuleTest.java
+++ b/src/test/java/org/creekservice/ModuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/creekservice/api/json/schema/gradle/plugin/GeneratorVersionTest.java
+++ b/src/test/java/org/creekservice/api/json/schema/gradle/plugin/GeneratorVersionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/creekservice/api/json/schema/gradle/plugin/task/GenerateJsonSchemaTest.java
+++ b/src/test/java/org/creekservice/api/json/schema/gradle/plugin/task/GenerateJsonSchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/projects/functional/groovy/generates_flat_schema/groovy/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/groovy/generates_flat_schema/groovy/src/test/java/acme/ModelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2025-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/projects/functional/groovy/generates_flat_schema/java-module/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/groovy/generates_flat_schema/java-module/src/test/java/acme/ModelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2025-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/projects/functional/groovy/generates_flat_schema/java/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/groovy/generates_flat_schema/java/src/test/java/acme/ModelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2025-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/projects/functional/groovy/generates_flat_schema/kotlin/src/main/kotlin/acme/Model.kt
+++ b/src/test/resources/projects/functional/groovy/generates_flat_schema/kotlin/src/main/kotlin/acme/Model.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2025-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/projects/functional/groovy/generates_flat_schema/kotlin/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/groovy/generates_flat_schema/kotlin/src/test/java/acme/ModelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2025-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/projects/functional/groovy/generates_schema/groovy/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/groovy/generates_schema/groovy/src/test/java/acme/ModelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2025-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/projects/functional/groovy/generates_schema/java-module/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/groovy/generates_schema/java-module/src/test/java/acme/ModelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2025-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/projects/functional/groovy/generates_schema/java/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/groovy/generates_schema/java/src/test/java/acme/ModelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2025-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/projects/functional/groovy/generates_schema/kotlin/src/main/kotlin/acme/Model.kt
+++ b/src/test/resources/projects/functional/groovy/generates_schema/kotlin/src/main/kotlin/acme/Model.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2025-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/projects/functional/groovy/generates_schema/kotlin/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/groovy/generates_schema/kotlin/src/test/java/acme/ModelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2025-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/projects/functional/groovy/generates_test_schema/groovy/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/groovy/generates_test_schema/groovy/src/test/java/acme/ModelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2025-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/projects/functional/groovy/generates_test_schema/java-module/src/main/java/acme/Other.java
+++ b/src/test/resources/projects/functional/groovy/generates_test_schema/java-module/src/main/java/acme/Other.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/projects/functional/groovy/generates_test_schema/java-module/src/test/java/acme/Model.java
+++ b/src/test/resources/projects/functional/groovy/generates_test_schema/java-module/src/test/java/acme/Model.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/projects/functional/groovy/generates_test_schema/java-module/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/groovy/generates_test_schema/java-module/src/test/java/acme/ModelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2025-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/projects/functional/groovy/generates_test_schema/java/src/test/java/acme/Model.java
+++ b/src/test/resources/projects/functional/groovy/generates_test_schema/java/src/test/java/acme/Model.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/projects/functional/groovy/generates_test_schema/java/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/groovy/generates_test_schema/java/src/test/java/acme/ModelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2025-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/projects/functional/groovy/generates_test_schema/kotlin/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/groovy/generates_test_schema/kotlin/src/test/java/acme/ModelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2025-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/projects/functional/groovy/generates_test_schema/kotlin/src/test/kotlin/acme/Model.kt
+++ b/src/test/resources/projects/functional/groovy/generates_test_schema/kotlin/src/test/kotlin/acme/Model.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/projects/functional/kotlin/generates_flat_schema/groovy/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/kotlin/generates_flat_schema/groovy/src/test/java/acme/ModelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2025-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/projects/functional/kotlin/generates_flat_schema/java-module/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/kotlin/generates_flat_schema/java-module/src/test/java/acme/ModelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2025-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/projects/functional/kotlin/generates_flat_schema/java/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/kotlin/generates_flat_schema/java/src/test/java/acme/ModelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2025-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/projects/functional/kotlin/generates_flat_schema/kotlin/src/main/kotlin/acme/Model.kt
+++ b/src/test/resources/projects/functional/kotlin/generates_flat_schema/kotlin/src/main/kotlin/acme/Model.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2025-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/projects/functional/kotlin/generates_flat_schema/kotlin/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/kotlin/generates_flat_schema/kotlin/src/test/java/acme/ModelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2025-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/projects/functional/kotlin/generates_schema/groovy/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/kotlin/generates_schema/groovy/src/test/java/acme/ModelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2025-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/projects/functional/kotlin/generates_schema/java-module/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/kotlin/generates_schema/java-module/src/test/java/acme/ModelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2025-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/projects/functional/kotlin/generates_schema/java/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/kotlin/generates_schema/java/src/test/java/acme/ModelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2025-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/projects/functional/kotlin/generates_schema/kotlin/src/main/kotlin/acme/Model.kt
+++ b/src/test/resources/projects/functional/kotlin/generates_schema/kotlin/src/main/kotlin/acme/Model.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2025-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/projects/functional/kotlin/generates_schema/kotlin/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/kotlin/generates_schema/kotlin/src/test/java/acme/ModelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2025-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/projects/functional/kotlin/generates_test_schema/groovy/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/kotlin/generates_test_schema/groovy/src/test/java/acme/ModelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2025-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/projects/functional/kotlin/generates_test_schema/java-module/build.gradle.kts
+++ b/src/test/resources/projects/functional/kotlin/generates_test_schema/java-module/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/projects/functional/kotlin/generates_test_schema/java-module/src/main/java/acme/Other.java
+++ b/src/test/resources/projects/functional/kotlin/generates_test_schema/java-module/src/main/java/acme/Other.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/projects/functional/kotlin/generates_test_schema/java-module/src/test/java/acme/Model.java
+++ b/src/test/resources/projects/functional/kotlin/generates_test_schema/java-module/src/test/java/acme/Model.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/projects/functional/kotlin/generates_test_schema/java-module/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/kotlin/generates_test_schema/java-module/src/test/java/acme/ModelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2025-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/projects/functional/kotlin/generates_test_schema/java/build.gradle.kts
+++ b/src/test/resources/projects/functional/kotlin/generates_test_schema/java/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/projects/functional/kotlin/generates_test_schema/java/src/test/java/acme/Model.java
+++ b/src/test/resources/projects/functional/kotlin/generates_test_schema/java/src/test/java/acme/Model.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/projects/functional/kotlin/generates_test_schema/java/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/kotlin/generates_test_schema/java/src/test/java/acme/ModelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2025-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/projects/functional/kotlin/generates_test_schema/kotlin/build.gradle.kts
+++ b/src/test/resources/projects/functional/kotlin/generates_test_schema/kotlin/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/projects/functional/kotlin/generates_test_schema/kotlin/src/test/java/acme/ModelTest.java
+++ b/src/test/resources/projects/functional/kotlin/generates_test_schema/kotlin/src/test/java/acme/ModelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2025-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/projects/functional/kotlin/generates_test_schema/kotlin/src/test/kotlin/acme/Model.kt
+++ b/src/test/resources/projects/functional/kotlin/generates_test_schema/kotlin/src/test/kotlin/acme/Model.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Update checkstyle header rule and existing copyright headers from 2025 to 2026.

Note: `./gradlew static` was not fully verifiable locally as test compilation requires SNAPSHOT dependencies that are not yet published (this is expected during active development). The `checkstyleMain` task passed successfully.